### PR TITLE
Use java.server.launchMode of "Standard"

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -17,12 +17,15 @@
     "CoenraadS.bracket-pair-colorizer-2",
 
     // Gradle language support
+    // https://marketplace.visualstudio.com/items?itemName=naco-siren.gradle-language
     "naco-siren.gradle-language",
 
     // Markdown All in One
+    // https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one
     "yzhang.markdown-all-in-one",
 
     // GitHub Markdown Preview
+    // https://marketplace.visualstudio.com/items?itemName=bierner.github-markdown-preview
     "bierner.github-markdown-preview"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "java.configuration.updateBuildConfiguration": "automatic"
+    "java.configuration.updateBuildConfiguration": "automatic",
+    "java.server.launchMode": "Standard"
 }


### PR DESCRIPTION
This means the VS Code Java plugin will always use "Standard" mode instead of "LightWeight" mode. 

See https://code.visualstudio.com/docs/java/java-project#_lightweight-mode