### PR TITLE
Change Better Code Hub badge URL to point to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 > repository so it's there each semester when we fork this.
 
 [![Continuous integration status](../../workflows/Java%20CI/badge.svg)](../../actions?query=workflow%3A"Java+CI")
-[![BCH compliance](https://bettercodehub.com/edge/badge/UMM-CSci-3601/intro-to-git?branch=master)](https://bettercodehub.com/)
+[![BCH compliance](https://bettercodehub.com/edge/badge/UMM-CSci-3601/intro-to-git?branch=main)](https://bettercodehub.com/)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/UMM-CSci-3601/intro-to-git.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/UMM-CSci-3601/intro-to-git/alerts/)
 
 * [Background](#background)


### PR DESCRIPTION
After changing from `master` to `main`, we needed to update the Better Code Hub badge so that it points to the correct branch.