### PR TITLE
Remove BetterCodeHub from list of required checks

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -37,7 +37,7 @@ branches:
         # Required. Require branches to be up to date before merging.
         strict: true
         # Required. The list of status checks to require in order to merge into this branch
-        contexts: ['build', 'Better Code Hub']
+        contexts: ['build']
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: true
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.


### PR DESCRIPTION
This removes BCH from the set of things that need to be checked before you can merge a PR. BCH has gone away, so we're removing all references to it.