### PR TITLE
Replace references to Slack with Discord

### DIFF
--- a/PART_2_JAVA_INTRODUCTIONS.md
+++ b/PART_2_JAVA_INTRODUCTIONS.md
@@ -347,7 +347,7 @@ The meaning of these symbols is:
   the tests passed, and any other checks passed as well).
 - ![GitHub's red failure x][red-x]: A red x means that
   something bad happened, like a test failed.
-  
+
 If you click on any of these symbols on the GitHub page, you can get
 more information, including links to pages with details on, e.g., failed tests.
 
@@ -614,7 +614,7 @@ Once you receive a positive review you can proceed to merge. If, however, you
 received a request to make some changes, look those over. Does the request make
 sense? Do you understand what (and why) it's being made? If not, _definitely_
 ask the requestor for further information or explanation. You can post your own comment
-on the pull request and/or contact them by other means (e.g., Slack, email). You
+on the pull request and/or contact them by other means (e.g., Discord, email). You
 probably want any important info to be captured in the pull request, but sometimes
 it's useful to poke someone on another channel to get their attention.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ of documentation we have in the `docs/` folder:
 - [An overview of the Gradle build tool and how we're using it in this lab](docs/Gradle_README.md)
 
 You should also probably read [Mastering Markdown](https://guides.github.com/features/mastering-markdown/).
-Markdown is the markup language used by Slack, GitHub, and _many_ other
+Markdown is the markup language used by Discord, Slack, GitHub, and _many_ other
 online tools, so understanding at least the basics is really valuable.
 
 Below are some additional resources that you might


### PR DESCRIPTION
There were only two, and I actually only replaced one of them. For the other, Slack was in a list of tools using Markdown, so it made sense to leave it, although I did actually add Discord as well.

Closes #117 