### PR TITLE
Add `merge_group` to all the workflow files

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,7 @@ name: "CodeQL"
 on:
   push:
   pull_request:
+  merge_group:
   schedule:
     - cron: "21 0 10 * *"
 

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -1,23 +1,22 @@
 name: Java
 
-on: [push]
+on: [push, pull_request, merge_group]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Cache Gradle artifacts (downloaded JARs, the wrapper, and any downloaded JDKs)
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-          ~/.gradle/jdks
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/.gradle/') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-    - name: Build with Gradle (which runs the tests as one of its subtasks)
-      run: ./gradlew build
+      - uses: actions/checkout@v1
+      - name: Cache Gradle artifacts (downloaded JARs, the wrapper, and any downloaded JDKs)
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.gradle/jdks
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/.gradle/') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Build with Gradle (which runs the tests as one of its subtasks)
+        run: ./gradlew build

--- a/.github/workflows/link-check.yaml
+++ b/.github/workflows/link-check.yaml
@@ -1,14 +1,14 @@
 name: Check Markdown links
 
-on: [push]
+on: [push, pull_request, merge_group]
 
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        use-quiet-mode: 'yes'
-        use-verbose-mode: 'yes'
-        config-file: '.github/mlc_config.json'
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: "yes"
+          use-verbose-mode: "yes"
+          config-file: ".github/mlc_config.json"


### PR DESCRIPTION
There's been some kind of change in the world, and GitHub now says that we're supposed to have `merge_group` as a trigger for all our workflows. This adds that.

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

I don't think we've been having problems by _not_ having this, but if it is indeed necessary (or going to be necessary), I figured I'd add it.

I'm a little worried about their comments about needing to configure 3rd party checks. It's possible that things like DeepSource will break (or fail to ever return a check) on these things?

It's possible that we're "safe" because we're triggering everything on `push`, which basically causes pretty much everything to be checked. I'm not at all sure, though.